### PR TITLE
Basic Build to spit out initrd and kernel as release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ jobs:
       if: (NOT (type IN (pull_request))) AND (tag IS blank)
       script:
         # Build image to create custom initrd
-        - export KERNEL_VERSION=$(curl -sX GET http://archive.ubuntu.com/ubuntu/dists/eoan/main/binary-amd64/Packages.gz | gunzip -c |grep -A 7 -m 1 "Package: linux-image-virtual" | awk -F ": " '/Version/{print $2;exit}')
+        - |
+          export KERNEL_VERSION=$(curl -sX GET http://archive.ubuntu.com/ubuntu/dists/eoan/main/binary-amd64/Packages.gz | gunzip -c |grep -A 7 -m 1 "Package: linux-image-virtual" | awk -F ": " '/Version/{print $2;exit}')
         - docker build --no-cache -f Dockerfile --build-arg KERNEL_VERSION=${KERNEL_VERSION} -t kernel .
         # Build the release contents
         - mkdir -p buildout

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+sudo: true
+
+language: bash
+
+services:
+  - docker
+
+env:
+  global:
+    - DEBIAN_FRONTEND="noninteractive"
+
+jobs:
+  include:
+    - stage: Build and deploy
+      if: (NOT (type IN (pull_request))) AND (tag IS blank)
+      script:
+        # Build image to create custom initrd
+        - export KERNEL_VERSION=$(curl -sX GET http://archive.ubuntu.com/ubuntu/dists/eoan/main/binary-amd64/Packages.gz | gunzip -c |grep -A 7 -m 1 "Package: linux-image-virtual" | awk -F ": " '/Version/{print $2;exit}')
+        - docker build --no-cache -f Dockerfile --build-arg KERNEL_VERSION=${KERNEL_VERSION} -t kernel .
+        # Build the release contents
+        - mkdir -p buildout
+        - docker run --rm -it -v $(pwd)/buildout:/buildout kernel
+      before_deploy:
+        # Set up git user name and tag this commit
+        - git config --local user.name $GIT_USERNAME
+        - git config --local user.email $GIT_EMAIL
+        - export TRAVIS_TAG=${KERNEL_VERSION}-$(echo ${TRAVIS_COMMIT} | cut -c1-8)-${TRAVIS_JOB_NUMBER}
+        - git tag $TRAVIS_TAG
+      deploy:
+        provider: releases
+        api_key: $GITHUB_TOKEN
+        file_glob: true
+        file: buildout/*
+        skip_cleanup: true
+        on:
+          branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:eoan
+
+# versioning
+ARG KERNEL_VERSION
+
+# environment settings
+ARG DEBIAN_FRONTEND="noninteractive"
+ENV XDG_CONFIG_HOME="/config/xdg"
+
+# add local files
+COPY /root /
+
+RUN \
+ echo "**** install deps ****" && \
+ apt-get update && \
+ apt-get install -y \
+	casper \
+	curl \
+	initramfs-tools \
+	isc-dhcp-client \
+	p7zip-full \
+	patch \
+	pixz \
+	psmisc \
+	wget && \
+ echo "**** patch casper ****" && \
+ patch /usr/share/initramfs-tools/scripts/casper < /patch && \
+ patch /usr/share/initramfs-tools/scripts/casper-bottom/24preseed < /preseed-patch && \
+ echo "**** install kernel ****" && \
+ if [ -z ${KERNEL_VERSION+x} ]; then \
+	KERNEL_VERSION=$(curl -sX GET http://archive.ubuntu.com/ubuntu/dists/eoan/main/binary-amd64/Packages.gz | gunzip -c |grep -A 7 -m 1 "Package: linux-image-virtual" | awk -F ": " '/Version/{print $2;exit}');\
+ fi && \
+ apt-get install -y \
+	linux-image-virtual=${KERNEL_VERSION} && \
+ echo "**** clean up ****" && \
+ mkdir /buildout && \
+ rm -rf \
+	/tmp/* \
+	/var/lib/apt/lists/* \
+	/var/tmp/*
+
+ENTRYPOINT [ "/build.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-
+# Do not use

--- a/root/build.sh
+++ b/root/build.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+# Copy initrd and kernel
+mv /boot/initrd.img-* /buildout/initrd
+mv /boot/vmlinuz-* /buildout/vmlinuz
+chmod 777 /buildout/*
+
+exit 0

--- a/root/patch
+++ b/root/patch
@@ -1,0 +1,23 @@
+--- casper	2019-10-14 15:29:05.000000000 +0000
++++ casper.new	2019-11-03 17:01:51.825405059 +0000
+@@ -255,16 +255,10 @@
+ 
+ do_urlmount() {
+     rc=1
+-    modprobe "${MP_QUIET}" isofs
+-
+-    [ "$quiet" != "y" ] && log_begin_msg "Trying to download and mount ${URL}"
+-
+-    target=$(basename "${URL}")
+-
+-    if wget "${URL}" -O "${target}"; then
+-        mount -o ro "${target}" "${mountpoint}" && rc=0
+-    fi
+-
++    mkdir -p ${mountpoint}
++    mount -t tmpfs -o size=`/bin/wget ${URL} --spider --server-response -O - 2>&1 | sed -ne '/Content-Length/{s/.*: //;p}'` tmpfs ${mountpoint}
++    mkdir -p ${mountpoint}/casper
++    if /bin/wget --progress=bar:force:noscroll ${URL} -O ${mountpoint}/casper/root.squashfs; then rc=0; fi
+     return ${rc}
+ }
+ 

--- a/root/preseed-patch
+++ b/root/preseed-patch
@@ -1,0 +1,15 @@
+--- 24preseed	2019-11-03 17:20:33.481971286 +0000
++++ 24preseed.new	2019-11-03 17:17:59.566325152 +0000
+@@ -67,10 +67,8 @@
+ 			locations="${x#file=} $locations"
+ 			;;
+ 		url=*)
+-			url_location="${x#url=}"
+-			start_network
+-			chroot /root wget -P /tmp "$url_location"
+-			locations="/tmp/$(basename "$url_location") $locations"
++			chroot /casper/root.squashfs
++			locations="/casper/root.squashfs $locations"
+ 			;;
+ 		*/*\?=*)
+ 			question="${x%%\?=*}"

--- a/root/usr/share/initramfs-tools/hooks/wget
+++ b/root/usr/share/initramfs-tools/hooks/wget
@@ -1,0 +1,25 @@
+#!/bin/sh -e
+## required header
+PREREQS=""
+case $1 in
+        prereqs) echo "${PREREQS}"; exit 0;;
+esac
+. /usr/share/initramfs-tools/hook-functions
+
+## add wget from eoan install
+copy_exec /usr/bin/wget /bin
+
+## copy ssl certs
+mkdir -p \
+	$DESTDIR/etc/ssl \
+	$DESTDIR/usr/share/ca-certificates/
+cp -a \
+	/etc/ssl/certs \
+	$DESTDIR/etc/ssl/
+cp -a \
+	/etc/ca-certificates \
+	$DESTDIR/etc/
+cp -a \
+	/usr/share/ca-certificates/mozilla \
+	$DESTDIR/usr/share/ca-certificates/
+echo "ca_directory=/etc/ssl/certs" > $DESTDIR/etc/wgetrc


### PR DESCRIPTION
This does not include logic we need to discuss and build for triggering upstream.

For this to work with travis we need a bot user and auth key capable of generating releases with the following Travis secrets set:

GITHUB_TOKEN
GIT_USERNAME
GIT_EMAIL

To do stuff off the top of my head down the line:
- template the build logic and the documentation in these repos as a travis build step
- determine how to push this new release upstream to build a new release there with the new reference files (my attempts to have a local yaml in this repo and be able to merge it into something upstream to generate new menus failed some basic smoke tests, need to brainstorm something)
